### PR TITLE
makes smoke powder not disappear when reacting in a closed container

### DIFF
--- a/code/modules/chemistry/Chemistry-Recipes.dm
+++ b/code/modules/chemistry/Chemistry-Recipes.dm
@@ -3472,6 +3472,25 @@
 		priority = 9
 #endif
 
+	smokeheat  //smoke powder's reaction when crossing the heat threshold
+		name = "Smoke Heat"
+		id   = "smokeheat"
+		required_reagents = list("smokepowder" = 1)
+		result_amount = 1
+		mix_phrase = "The mixture quickly turns into a pall of smoke!"
+		hidden = TRUE
+		min_temperature = T0C + 25
+
+		does_react(var/datum/reagents/holder) //making sure it doesn't smoke itself while inside a closed container
+			if (holder.my_atom && holder.my_atom.is_open_container() || istype(holder,/datum/reagents/fluid_group))
+				return TRUE
+			else
+				return FALSE
+
+		on_reaction(var/datum/reagents/holder, var/created_volume)
+			if (holder)
+				holder.smoke_start(created_volume)
+
 	smoke
 		name = "Smoke"
 		id = "smoke"
@@ -3485,14 +3504,14 @@
 #ifdef CHEM_REACTION_PRIORITY
 		priority = 9
 #endif
-		on_reaction(var/datum/reagents/holder, var/created_volume) //moved to a proc in Chemistry-Holder.dm so that the instant reaction and powder can use the same proc
+		does_react(var/datum/reagents/holder) //making sure it doesn't smoke itself while inside a closed container
+			if (holder.my_atom && holder.my_atom.is_open_container() || istype(holder,/datum/reagents/fluid_group))
+				return TRUE
+			else
+				return FALSE
 
+		on_reaction(var/datum/reagents/holder, var/created_volume) //moved to a proc in Chemistry-Holder.dm so that the instant reaction and powder can use the same proc
 			if (holder)
-				if(!holder?.my_atom?.is_open_container())
-					if(holder.my_atom)
-						for(var/mob/M in AIviewers(5, get_turf(holder.my_atom)))
-							boutput(M, "<span class='notice'>With nowhere to go, the smoke settles.</span>")
-						return
 				holder.smoke_start(created_volume)
 
 	blackpowder // oh no

--- a/code/modules/chemistry/Reagents-ExplosiveFire.dm
+++ b/code/modules/chemistry/Reagents-ExplosiveFire.dm
@@ -243,20 +243,7 @@ datum
 			fluid_g = 200
 			fluid_b = 200
 			transparency = 230
-			minimum_reaction_temperature = T0C+25
-			var/ignited = 0
-
-			reaction_temperature(exposed_temperature, exposed_volume)
-				var/datum/reagents/myholder = holder
-				var/vol = volume
-				myholder.del_reagent(id)
-				if(!myholder?.my_atom?.is_open_container() && !istype(myholder, /datum/reagents/fluid_group))
-					if(myholder.my_atom)
-						for(var/mob/M in AIviewers(5, get_turf(myholder.my_atom)))
-							boutput(M, "<span class='notice'>With nowhere to go, the smoke settles.</span>")
-				else if(!ignited)
-					ignited = 1
-					myholder.smoke_start(vol) //moved to a proc in Chemistry-Holder.dm so that the instant reaction and powder can use the same proc
+			// Heat reaction moved to reactions to account for opening and closing containers
 
 		combustible/propellant
 			name = "aerosol propellant"


### PR DESCRIPTION
[LABEL][chemistry][balance]

## About the PR <!-- Describe the Pull Request here. What does it change? What other things could this impact? -->
This PR makes it so smoke powder no longer disappears if it reacts in a closed space, instead, remaining dormant until it is able to expand.


## Why's this needed? <!-- Describe why you think this should be added to the game. -->
It seems rather weird to have the reagent simply disappear when it has nowhere to go, this version makes it react more like steam, that leaves a container as soon as the lid is opened.


```changelog
(u)Colossusqw
(+)Smoke powder no longer fizzles into nothing when in a closed container, instead, reacting only when it is opened.
```
